### PR TITLE
Adopt the sate of promises without taking a reference

### DIFF
--- a/lib/promise.js
+++ b/lib/promise.js
@@ -26,6 +26,10 @@ function CreateResolvingFunctions(promise) {
         return RejectPromise(promise, selfResolutionError);
       }
 
+      if (IsPromise(resolution) === true) {
+        return AdoptPromise(promise, resolution);
+      }
+
       if (Type(resolution) !== "Object") {
         return FulfillPromise(promise, resolution);
       }
@@ -53,6 +57,40 @@ function CreateResolvingFunctions(promise) {
       return RejectPromise(promise, reason);
     }
   };
+}
+
+function AdoptPromise(promise, resolution) {
+  assert(get_slot(promise, "[[PromiseState]]") === "pending");
+  assert(IsPromise(promise) === true);
+  assert(IsPromise(resolution) === true);
+  
+  while (get_slot(resolution, "[[PromiseState]]") === "adopted") {
+    resolution = get_slot(resolution, "[[PromiseResult]]");
+    assert(IsPromise(resolution) === true);
+  }
+
+  if (get_slot(resolution, "[[PromiseState]]") === "pending") {
+    const fulfillReactionsPromise = get_slot(promise, "[[PromiseFulfillReactions]]");
+    const fulfillReactionsResolution = get_slot(resolution, "[[PromiseFulfillReactions]]");
+    for (const reaction of fulfillReactionsPromise) {
+      fulfillReactionsResolution.push(reaction);
+    }
+    const rejectReactionsPromise = get_slot(promise, "[[PromiseRejectReactions]]");
+    const rejectReactionsResolution = get_slot(resolution, "[[PromiseRejectReactions]]");
+    for (const reaction of rejectReactionsPromise) {
+      rejectReactionsResolution.push(reaction);
+    }
+    set_slot(promise, "[[PromiseResult]]", resolution);
+    set_slot(promise, "[[PromiseFulfillReactions]]", undefined);
+    set_slot(promise, "[[PromiseRejectReactions]]", undefined);
+    set_slot(promise, "[[PromiseState]]", "adopted");
+  } else if (get_slot(resolution, "[[PromiseState]]") === "fulfilled") {
+    const value = get_slot(resolution, "[[PromiseResult]]");
+    FulfillPromise(promise, value);
+  } else if (get_slot(resolution, "[[PromiseState]]") === "rejected") {
+    const reason = get_slot(resolution, "[[PromiseResult]]");
+    RejectPromise(promise, reason);
+  }
 }
 
 function FulfillPromise(promise, value) {
@@ -348,6 +386,10 @@ export function PerformPromiseThen(promise, onFulfilled, onRejected, resultCapab
   const fulfillReaction = { Capabilities: resultCapability, Handler: onFulfilled };
   const rejectReaction = { Capabilities: resultCapability, Handler: onRejected };
 
+  while (get_slot(promise, "[[PromiseState]]") === "adopted") {
+    promise = get_slot(promise, "[[PromiseResult]]");
+    assert(IsPromise(promise) === true);
+  }
   if (get_slot(promise, "[[PromiseState]]") === "pending") {
     get_slot(promise, "[[PromiseFulfillReactions]]").push(fulfillReaction);
     get_slot(promise, "[[PromiseRejectReactions]]").push(rejectReaction);


### PR DESCRIPTION
See promises-aplus/promises-spec#179

The basic idea is to implement a new state "adopted", which reverses the references.  Incidentally, it's still possible to get a memory leak with something like:

```js
function run() {
    return  new Promise(function(resolve) {
        setImmediate(resolve);
    }).then(run);
}

// here this `x` will keep a reference to the entire gradually expanding chain of promises
var x = run();
```

but this fixes the leak in the case of:

```js
function run() {
    return  new Promise(function(resolve) {
        setImmediate(resolve);
    }).then(run);
}
run().then(function () {
  console.log('this never actually gets called');
});
```

I'm not sure if it's possible to fix both scenarios.