### PR TITLE
Allow browserify to bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "traceur-runner": "^2.0.1"
   },
   "dependencies": {
-    "especially": "^2.0.0"
+    "especially": "git+ssh://git@github.com:birdy-/especially.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
     "test-non-aplus": "mocha --compilers js:mocha-traceur test/*.js",
     "test": "npm run test-aplus-promise && npm run test-aplus-cancelable-promise && npm run test-non-aplus"
   },
+  "browserify": {
+    "transform": [
+      "babelify"
+    ]
+  },
   "devDependencies": {
     "mocha": "^2.2.4",
     "mocha-traceur": "^2.1.0",


### PR DESCRIPTION
This conf is enough to allow browserify to bundle this dep.
See http://stackoverflow.com/questions/30386317/babelify-parseerror-on-import-module-from-node-modules
Not sure if you should add babelify as a dependency.